### PR TITLE
Fix helper programs for Django 1.8+

### DIFF
--- a/binary_database_files/management/commands/database_files_cleanup.py
+++ b/binary_database_files/management/commands/database_files_cleanup.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.core.files.storage import default_storage
 from django.core.management.base import BaseCommand
 from django.db.models import FileField, ImageField
-from django.apps.apps import get_models
+from django.apps import apps
 
 from binary_database_files.models import File
 
@@ -15,8 +15,9 @@ class Command(BaseCommand):
         "Deletes all files in the database that are not referenced by "
         "any model fields."
     )
-    option_list = BaseCommand.option_list + (
-        make_option(
+
+    def add_arguments(self, parser):
+        parser.add_argument(
             "--dryrun",
             action="store_true",
             dest="dryrun",
@@ -24,14 +25,13 @@ class Command(BaseCommand):
             help=(
                 "If given, only displays the names of orphaned files "
                 "and does not delete them."
-            ),
-        ),
-        make_option(
+            )
+        )
+        parser.add_argument(
             "--filenames",
             default="",
             help="If given, only files with these names will be checked",
-        ),
-    )
+        )
 
     def handle(self, *args, **options):
         tmp_debug = settings.DEBUG
@@ -40,7 +40,7 @@ class Command(BaseCommand):
         dryrun = options["dryrun"]
         filenames = {_.strip() for _ in options["filenames"].split(",") if _.strip()}
         try:
-            for model in get_models():
+            for model in apps.get_models():
                 print("Checking model %s..." % (model,))
                 for field in model._meta.fields:
                     if not isinstance(field, (FileField, ImageField)):

--- a/binary_database_files/management/commands/database_files_dump.py
+++ b/binary_database_files/management/commands/database_files_dump.py
@@ -4,11 +4,6 @@ from binary_database_files.models import File
 
 
 class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
-        #        make_option('-w', '--overwrite', action='store_true',
-        #            dest='overwrite', default=False,
-        #            help='If given, overwrites any existing files.'),
-    )
     help = (
         "Dumps all files in the database referenced by FileFields "
         "or ImageFields onto the filesystem in the directory specified by "

--- a/binary_database_files/management/commands/database_files_load.py
+++ b/binary_database_files/management/commands/database_files_load.py
@@ -1,27 +1,26 @@
 import os
-from optparse import make_option
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db.models import FileField, ImageField
-from django.apps.apps import get_models
+from django.apps import apps
 
 
 class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
-        make_option(
-            "-m",
-            "--models",
-            dest="models",
-            default="",
-            help="A list of models to search for file fields. Default is all.",
-        ),
-    )
     help = (
         "Loads all files on the filesystem referenced by FileFields "
         "or ImageFields into the database. This should only need to be "
         "done once, when initially migrating a legacy system."
     )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-m",
+            "--models",
+            dest="models",
+            default="",
+            help="A list of models to search for file fields. Default is all."
+        )
 
     def handle(self, *args, **options):
         show_files = int(options.get("verbosity", 1)) >= 2
@@ -32,8 +31,8 @@ class Command(BaseCommand):
         settings.DEBUG = False
         try:
             broken = 0  # Number of db records referencing missing files.
-            for model in get_models():
-                key = "%s.%s" % (model._meta.app_label, model._meta.module_name)
+            for model in apps.get_models():
+                key = "%s.%s" % (model._meta.app_label, model._meta.model_name)
                 key = key.lower()
                 if all_models and key not in all_models:
                     continue


### PR DESCRIPTION
Don't include django.apps.apps, at least in Django 2.2.13 apps is a
field in django.apps only. Don't use old module_name attribute, it was
renamed to model_name.

Fix argument handling to not depend on the old argument parser that was
removed in Django 1.8.