### PR TITLE
tests: Set DEFAULT_FILE_STORAGE when needed

### DIFF
--- a/binary_database_files/tests/settings.py
+++ b/binary_database_files/tests/settings.py
@@ -15,8 +15,6 @@ INSTALLED_APPS = [
     "binary_database_files.tests",
 ]
 
-DEFAULT_FILE_STORAGE = "binary_database_files.storage.DatabaseStorage"
-
 MEDIA_ROOT = os.path.join(PROJECT_DIR, "media")
 
 USE_TZ = True


### PR DESCRIPTION
Many of the tests use explicit storage in the test models,
so they should be tested without the default file storage.
Use `override_settings` to set it only for tests which use
implicit storage.