### PR TITLE
Check field's file type before load

### DIFF
--- a/binary_database_files/management/commands/database_files_load.py
+++ b/binary_database_files/management/commands/database_files_load.py
@@ -1,4 +1,5 @@
 import os
+from binary_database_files.storage import DatabaseFile
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
@@ -50,6 +51,8 @@ class Command(BaseCommand):
                             if f is None:
                                 continue
                             if not f.name:
+                                continue
+                            if type(f.file) == DatabaseFile:
                                 continue
                             if show_files:
                                 print("\t", f.name)


### PR DESCRIPTION
This PR resolves a problem when some files are saved to a DB while the rest are not loaded yet. Example: `model.file.save()` was called by running application before invocation of `database_files_load` management command.