### PR TITLE
:bug: Fix delete file with auto export config

### DIFF
--- a/binary_database_files/storage.py
+++ b/binary_database_files/storage.py
@@ -142,9 +142,10 @@ class DatabaseStorage(FileSystemStorage):
         name = self.get_instance_name(name)
         try:
             models.File.objects.get_from_name(name).delete()
-            hash_fn = utils.get_hash_fn(name)
-            if os.path.isfile(hash_fn):
-                os.remove(hash_fn)
+            if _settings.DB_FILES_AUTO_EXPORT_DB_TO_FS:
+                hash_fn = utils.get_hash_fn(name)
+                if os.path.isfile(hash_fn):
+                    os.remove(hash_fn)
         except models.File.DoesNotExist:
             pass
         localpath = self._path(name)


### PR DESCRIPTION
When calling `DatabaseStorage.delete`, there is a process that deletes the cache if it exists on the file system, and in the `get_hash_fn` function called in that process, if the destination directory for the cache file does not exist on the file system, it creates it. If there is no directory on the file system to store the cache file, the process creates it.