### PR TITLE
Use Django default file mode-settings for uploaded files, and limit use of system()

### DIFF
--- a/binary_database_files/storage.py
+++ b/binary_database_files/storage.py
@@ -54,7 +54,8 @@ class DatabaseStorage(FileSystemStorage):
             fqfn = self.path(name)
             if os.path.isfile(fqfn):
                 # print('Loading file into database.')
-                self._save(name, open(fqfn, mode))
+                with open(fqfn, mode) as fd:
+                    self._save(name, fd)
                 fh = super(DatabaseStorage, self)._open(name, mode)
                 content = fh.read()
                 size = fh.size

--- a/binary_database_files/utils.py
+++ b/binary_database_files/utils.py
@@ -60,7 +60,9 @@ def write_file(name, content, overwrite=False):
     fqfn_parts = os.path.split(fqfn)
     if not os.path.isdir(fqfn_parts[0]):
         os.makedirs(fqfn_parts[0])
-    open(fqfn, "wb").write(content)
+
+    with open(fqfn, "wb") as fd:
+        fd.write(content)
 
     # Cache hash.
     hash_value = get_file_hash(fqfn)
@@ -69,7 +71,9 @@ def write_file(name, content, overwrite=False):
         value = bytes(hash_value, "utf-8")
     except TypeError:
         value = hash_value
-    open(hash_fn, "wb").write(value)
+
+    with open(hash_fn, "wb") as fd:
+        fd.write(value)
 
     # Set ownership and permissions.
     uname = getattr(settings, "DATABASE_FILES_USER", None)


### PR DESCRIPTION
These commits make the following changes:

* Use context manager to make sure file handlers are closed directly after use
* Use Django settings `FILE_UPLOAD_PERMISSIONS` and `FILE_UPLOAD_DIRECTORY_PERMISSIONS` as fallback to determinate new file- and directory modes. This also makes sure to use correct permissions for all created subdirectories.
* Use `shutil.chown()` and `os.chmod()` instead of spawning separate shell command to recursively change file permissions

The `shutil.chown()` and `os.chmod()` also fixes an issue where the previous recursive command may set incompatible permissions on any subdirectories for the path (e.g. no +x-permissions) 

In case you would want me to split the pull request, using `settings.FILE_UPLOAD_PERMISSIONS` will need separate handling to not overwrite directory permissions due to the recursive flag in the system-command.