### PR TITLE
Ensure urls do not contain backward slashes on windows (#67)

### DIFF
--- a/binary_database_files/settings.py
+++ b/binary_database_files/settings.py
@@ -1,4 +1,4 @@
-import os
+from urllib.parse import urljoin
 
 from django.conf import settings
 from django.urls import reverse
@@ -14,7 +14,7 @@ def URL_METHOD_1(name):
     """
     Construct file URL based on media URL.
     """
-    return os.path.join(settings.MEDIA_URL, name)
+    return urljoin(settings.MEDIA_URL, name)
 
 
 def URL_METHOD_2(name):

--- a/binary_database_files/storage.py
+++ b/binary_database_files/storage.py
@@ -159,7 +159,8 @@ class DatabaseStorage(FileSystemStorage):
         We could also raise an error like the SFTP backend of django-storages is doing, but the relative URL is the
         previous behavior so we fall back to that.
         """
-        return "{}{}".format(self._base_url, settings.DATABASE_FILES_URL_METHOD(name))
+        url_name = name.replace('\\', '/')
+        return "{}{}".format(self._base_url, settings.DATABASE_FILES_URL_METHOD(url_name))
 
     def size(self, name):
         """Return the size of the file with filename `name` in bytes."""


### PR DESCRIPTION
A minimal fix to not expose `\` in URLs on a Windows server.
Tests fail on Windows, because file names are assumed to contain `/` but contain `\`. This patch does not change that or add new tests.